### PR TITLE
Completions Limit for ScheduledResource

### DIFF
--- a/deploy/crds/cloud.namecheap.com_scheduledresources.yaml
+++ b/deploy/crds/cloud.namecheap.com_scheduledresources.yaml
@@ -56,13 +56,13 @@ spec:
             type: object
           spec:
             properties:
+              completions:
+                minimum: 1
+                type: integer
               content:
                 type: string
               schedule:
                 type: string
-              completions:
-                type: integer
-                minimum: 1
             required:
             - content
             - schedule

--- a/deploy/crds/cloud.namecheap.com_scheduledresources.yaml
+++ b/deploy/crds/cloud.namecheap.com_scheduledresources.yaml
@@ -27,6 +27,9 @@ spec:
     - jsonPath: .status.condition
       name: Condition
       type: string
+    - jsonPath: .status.completions
+      name: Completions
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -57,12 +60,17 @@ spec:
                 type: string
               schedule:
                 type: string
+              completions:
+                type: integer
+                minimum: 1
             required:
             - content
             - schedule
             type: object
           status:
             properties:
+              completions:
+                type: integer
               condition:
                 type: string
               lastRun:

--- a/docs/api.md
+++ b/docs/api.md
@@ -66,7 +66,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `schedule` _string_ |  |  |  |
-| `completions` _integer_ |  |  |  |
+| `completions` _integer_ |  |  | Minimum: 1 <br /> |
 | `content` _string_ |  |  |  |
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -66,6 +66,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `schedule` _string_ |  |  |  |
+| `completions` _integer_ |  |  |  |
 | `content` _string_ |  |  |  |
 
 
@@ -85,5 +86,6 @@ _Appears in:_
 | `nextRun` _string_ |  |  |  |
 | `lastRun` _string_ |  |  |  |
 | `condition` _[Condition](#condition)_ |  |  |  |
+| `completions` _integer_ |  |  |  |
 
 

--- a/examples/scheduled-resource-with-completions-limit.yaml
+++ b/examples/scheduled-resource-with-completions-limit.yaml
@@ -1,0 +1,15 @@
+apiVersion: cloud.namecheap.com/v1alpha2
+kind: ScheduledResource
+metadata:
+  name: scheduled-resource-cronjob-with-completions-limit
+spec:
+  schedule: "*/20 * * * * *" # Creates every 20 seconds
+  completions: 3 # Creates only 3 of them
+  content: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      generateName: scheduled-resource-cronjob-with-completions-limit-
+      namespace: default
+    data:
+      .secret-file: dmFsdWUtMg0KDQo=

--- a/pkg/apis/v1alpha2/scheduled_resource_types.go
+++ b/pkg/apis/v1alpha2/scheduled_resource_types.go
@@ -31,6 +31,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Next Run",type=string,JSONPath=".status.nextRun"
 // +kubebuilder:printcolumn:name="Last Run",type=string,JSONPath=".status.lastRun"
 // +kubebuilder:printcolumn:name="Condition",type=string,JSONPath=".status.condition"
+// +kubebuilder:printcolumn:name="Completions",type=string,JSONPath=".status.completions"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp"
 
 type ScheduledResource struct {
@@ -50,8 +51,9 @@ type ScheduledResourceList struct {
 }
 
 type ScheduledResourceSpec struct {
-	Schedule    string `json:"schedule"`
-	Completions int    `json:"completions"`
+	Schedule string `json:"schedule"`
+	// +kubebuilder:validation:Minimum=1
+	Completions int    `json:"completions,omitempty"`
 	Content     string `json:"content"`
 }
 

--- a/pkg/apis/v1alpha2/scheduled_resource_types.go
+++ b/pkg/apis/v1alpha2/scheduled_resource_types.go
@@ -50,14 +50,16 @@ type ScheduledResourceList struct {
 }
 
 type ScheduledResourceSpec struct {
-	Schedule string `json:"schedule"`
-	Content  string `json:"content"`
+	Schedule    string `json:"schedule"`
+	Completions int    `json:"completions"`
+	Content     string `json:"content"`
 }
 
 type ScheduledResourceStatus struct {
-	NextRun   string    `json:"nextRun,omitempty"`
-	LastRun   string    `json:"lastRun,omitempty"`
-	Condition Condition `json:"condition,omitempty"`
+	NextRun     string    `json:"nextRun,omitempty"`
+	LastRun     string    `json:"lastRun,omitempty"`
+	Condition   Condition `json:"condition,omitempty"`
+	Completions int       `json:"completions,omitempty"`
 }
 
 func (in *ScheduledResource) IsBeingDeleted() bool {

--- a/pkg/apis/v1alpha2/scheduled_resource_types.go
+++ b/pkg/apis/v1alpha2/scheduled_resource_types.go
@@ -82,3 +82,8 @@ func (in *ScheduledResource) GetContent() (*unstructured.Unstructured, error) {
 
 	return unstructuredObj, nil
 }
+
+func (in *ScheduledResource) IsCompletionsLimitReached(isOneTimeSchedule bool) bool {
+	return isOneTimeSchedule && in.Status.Completions >= 1 ||
+		in.Spec.Completions > 0 && in.Status.Completions >= in.Spec.Completions
+}

--- a/pkg/controllers/scheduledresource/controller.go
+++ b/pkg/controllers/scheduledresource/controller.go
@@ -55,6 +55,7 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if isOneTimeSchedule && scheduledResource.Status.Condition == v1alpha2.ConditionFinished ||
 		scheduledResource.Spec.Completions > 0 && scheduledResource.Status.Completions >= scheduledResource.Spec.Completions {
+
 		return ctrl.Result{}, nil
 	}
 
@@ -96,6 +97,7 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		scheduledResource.Status.Completions++
 		if scheduledResource.Spec.Completions > 0 &&
 			scheduledResource.Status.Completions >= scheduledResource.Spec.Completions {
+
 			_ = r.scheduler.DeleteTask(tag)
 			scheduledResource.Status.Condition = v1alpha2.ConditionFinished
 			scheduledResource.Status.NextRun = ""

--- a/pkg/controllers/scheduledresource/controller.go
+++ b/pkg/controllers/scheduledresource/controller.go
@@ -53,7 +53,8 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		scheduledResource.CreationTimestamp, scheduledResource.Spec.Schedule)
 	isOneTimeSchedule := oneTimeScheduleErr == nil
 
-	if scheduledResource.Status.Condition == v1alpha2.ConditionFinished {
+	if isOneTimeSchedule && scheduledResource.Status.Condition == v1alpha2.ConditionFinished ||
+		scheduledResource.Spec.Completions > 0 && scheduledResource.Status.Completions >= scheduledResource.Spec.Completions {
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
Hello :wave: 

This PR solves the following problem
_I want to create a resource every X time period but I only want to create Y of them_

Also adds `COMPLETIONS` column to the `printerColumns` of the `ScheduledResource` CRD.

Concretely, I've added an optional integer field, `completions` to the `ScheduledResource` CRD. Currently it has a small validation that it can't be lower than 1 when it's set.

### Example resource definition
![image](https://github.com/user-attachments/assets/7e6eb991-a5c4-4928-ace5-5a65d3db070b)

### Example kubectl outputs
![image](https://github.com/user-attachments/assets/44c070ee-4a3b-433d-ab4c-f7a424994114)
Should be the same right after resource creation

---

![image](https://github.com/user-attachments/assets/dff65f05-7870-4c84-8879-6476907e3b48)
After it creates a resource `completion` times, `Condition` switches to `Finished` and `Next Run` is cleared

