### PR TITLE
Fixing go run command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ kind create cluster
 
 ```bash
 export RESOURCES=v1;Secret # Mayfly will begin monitoring secrets in the cluster. For more information, see the configuration section.
-go run .
+go run ./cmd/manager/main.go
 ```
 
 ## 🏷️ Versioning


### PR DESCRIPTION
Hello :wave: 

This small PR fixes the command in README.md file.
Currently it outputs `no Go files in ~/repos/mayfly`